### PR TITLE
Delay start until database available

### DIFF
--- a/nextcloud/11.0/run.sh
+++ b/nextcloud/11.0/run.sh
@@ -16,6 +16,21 @@ for dir in /nextcloud /data /config /apps2 /etc/nginx /etc/php7 /var/log /var/li
   fi
 done
 
+#Wait until the database is running
+if [ $DB_TYPE = pgsql ]; then
+       until pg_isready -h DB_HOST; do
+              >&2 echo "Not yet starting instance: Postgres host:$DB_HOST is not (yet) available - retry in 1s"
+              sleep 1
+       done
+fi
+
+if [ $DB_TYPE = mysql ]; then
+       until mysqladmin ping -h"$DB_HOST" --silent; do
+              >&2 echo "Not yet starting instance: mysql host:$DB_HOST is not (yet) available - retry in 1s"
+              sleep 1
+       done
+fi
+
 if [ ! -f /config/config.php ]; then
     # New installation, run the setup
     /usr/local/bin/setup.sh


### PR DESCRIPTION
Do not start the instance unless the database is up and running.
Without this care needs to be taken to first start the database, followed by starting nextcloud.
This makes the usage of docker-compose.yml cumbersome